### PR TITLE
Fix: Remove final useLocalStorage import from group-context-menu

### DIFF
--- a/components/groups/group-context-menu.tsx
+++ b/components/groups/group-context-menu.tsx
@@ -14,7 +14,6 @@ import type { TaskGroup, User, GuestUser, UserSettings } from "@/types"
 import GroupFormModal from "./group-form-modal"
 import { toast } from "sonner"
 import { createClient } from "@/lib/supabase/client"
-import { useLocalStorage } from "@/hooks/use-local-storage"
 
 interface GroupContextMenuProps {
   group: TaskGroup
@@ -35,12 +34,11 @@ export default function GroupContextMenu({
 }: GroupContextMenuProps) {
   const [showEditModal, setShowEditModal] = useState(false)
   const [loading, setLoading] = useState(false)
-  // localTasks is kept for taskCount as per instructions, though ideally this count should come from Supabase.
-  const [localTasks, setLocalTasks] = useLocalStorage("aura-tasks", [])
   const showToast = toast
   const supabase = createClient() // Initialize Supabase client directly
 
   const handleDeleteGroup = async () => {
+    // The taskCount prop is used here directly.
     if (taskCount > 0) {
       showToast("امکان حذف گروه وجود ندارد", {
         description: "ابتدا تمام وظایف این گروه را حذف یا به گروه دیگری منتقل کنید.",


### PR DESCRIPTION
This commit removes the last remaining import of the deleted `@/hooks/use-local-storage` hook from
`components/groups/group-context-menu.tsx`.

The component was using this hook to derive a `taskCount`. It has been refactored to correctly use the `taskCount` prop that was already available in its interface. This change is expected to resolve the persistent "Module not found" build error.

All core data persistence has been previously migrated to Supabase, and the `use-local-storage.ts` hook itself has been removed. This commit cleans up the final reference to ensure a successful build.